### PR TITLE
Place copyright symbol before site name

### DIFF
--- a/client/src/app/components/footer/footer.html
+++ b/client/src/app/components/footer/footer.html
@@ -6,6 +6,6 @@
 
 
 
-    <p>L.O.B 2026&#xA9;</p>
+    <p>&#xA9;L.O.B 2026</p>
   </div>
 </footer>


### PR DESCRIPTION
Moved HTML entity '&#xA9;' to precede 'L.O.B 2026' in footer.html so the © appears before the site name. Purely presentational change with no functional impact.